### PR TITLE
Allow port reuse so that other integrations can read the same port

### DIFF
--- a/custom_components/localtuya/discovery.py
+++ b/custom_components/localtuya/discovery.py
@@ -43,10 +43,10 @@ class TuyaDiscovery(asyncio.DatagramProtocol):
         """Start discovery by listening to broadcasts."""
         loop = asyncio.get_running_loop()
         listener = loop.create_datagram_endpoint(
-            lambda: self, local_addr=("0.0.0.0", 6666)
+            lambda: self, local_addr=("0.0.0.0", 6666), reuse_port=True
         )
         encrypted_listener = loop.create_datagram_endpoint(
-            lambda: self, local_addr=("0.0.0.0", 6667)
+            lambda: self, local_addr=("0.0.0.0", 6667), reuse_port=True
         )
 
         self._listeners = await asyncio.gather(listener, encrypted_listener)


### PR DESCRIPTION
👋 I've recently taken over maintainership of the [robovac integration](https://github.com/codefoodpixels/robovac) and have added autodiscovery to keep the IP addresses up to date. Someone mentioned that they were having issues with both the robovac and localtuya integrations running at the same time, and I believe that adding this to both of our integrations should resolve the issue.